### PR TITLE
config command updated: personalize your scanner now

### DIFF
--- a/cmd/adapters/analysis/parser.go
+++ b/cmd/adapters/analysis/parser.go
@@ -76,7 +76,7 @@ func CyclicalComplexity(languageInfo types.NodeManagement, code *[]string) []*do
 			// Add the initial data to the object reference in the stack
 			Stack[len(Stack)-1].AddInitialData(
 				(*code)[copyOf.Captures[1].Node.StartPosition().Row][copyOf.Captures[1].Node.StartPosition().Column:copyOf.Captures[1].Node.EndPosition().Column],
-				int(copyOf.Captures[2].Node.NamedChildCount()),
+				copyOf.Captures[2].Node.NamedChildCount(),
 				copyOf.Captures[3].Node.StartByte(), copyOf.Captures[3].Node.EndByte(),
 				copyOf.Captures[3].Node.EndPosition().Row-copyOf.Captures[2].Node.StartPosition().Row,
 				domain.Point(copyOf.Captures[2].Node.StartPosition()),

--- a/cmd/adapters/config/json.go
+++ b/cmd/adapters/config/json.go
@@ -12,11 +12,6 @@ import (
  * json.go - > manages the json files.
  */
 
-// ConfigDto gets the value of the current index on the config file (JSON, etc.).
-type ConfigDto struct {
-	NamingConventionIndex int8 `json:"activeNamingConventionIndex"`
-}
-
 type JsonAdapter struct {
 	configPath string
 }
@@ -26,18 +21,16 @@ func NewJSONAdapter() *JsonAdapter {
 }
 
 func (json *JsonAdapter) GetConfig() *domain.Config {
-	var dto *ConfigDto
+	var dto *domain.Config
 	err := encoder.Unmarshal(json.readJsonData(), &dto)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Couldn't read the JSON file. Are you sure it exists?")
 		os.Exit(1)
 	}
-	return &domain.Config{
-		NamingConventionIndex: dto.NamingConventionIndex,
-	}
+	return dto
 }
 
-func (json *JsonAdapter) SaveConfig(cfg *ConfigDto) {
+func (json *JsonAdapter) SaveConfig(cfg *domain.Config) {
 	data, err := encoder.Marshal(&cfg)
 	if err != nil {
 		os.Exit(1)

--- a/cmd/domain/dto.go
+++ b/cmd/domain/dto.go
@@ -1,0 +1,21 @@
+package domain
+
+// the 'dto' folder contains all the data transfer objects used mainly in the configuration set up.
+
+// Config gets the value of the current index on the config file (JSON, etc.).
+type Config struct {
+	NamingConventionIndex int8   `json:"activeNamingConventionIndex"`
+	Alerts                Alerts `json:"alerts"`
+}
+
+type Alerts struct {
+	Parameters FeedbackValues `json:"parameters"`
+	Complexity FeedbackValues `json:"complexity"`
+	MethodSize FeedbackValues `json:"method-length"`
+}
+
+type FeedbackValues struct {
+	Info    uint `json:"info"`
+	Warning uint `json:"warning"`
+	Error   uint `json:"error"`
+}

--- a/cmd/domain/feedback.go
+++ b/cmd/domain/feedback.go
@@ -2,24 +2,46 @@ package domain
 
 // Feedback is used to send messages to the user when a something is >= value
 type Feedback struct {
-	Value   int
-	Message string
+	configAdapter *Config
+	messages      map[string][]Message
 }
 
-var Messages = map[string][]Feedback{
-	"parameters": {
-		Feedback{Value: 5, Message: "   WARNING: The function takes more parameters than recommended.\n"},
-		Feedback{Value: 8, Message: "   WARNING: The function is dangerous and has many responsibilities.\n    You may want to make it cleaner/readable.\n"},
-		Feedback{Value: 10, Message: "   POTENTIAL ERROR: The function takes too much parameters itself. You should simplify it.\n"},
-	},
-	"complexity": {
-		Feedback{Value: 10, Message: "   WARNING: The function it's a little bit complex.\n"},
-		Feedback{Value: 15, Message: "   POTENTIAL ERROR: The function it's very complex itself. You may simplify or break it down.\n"},
-		Feedback{Value: 20, Message: "   POTENTIAL ERROR: The function it's too complex and unreadable, taking too much decisions.\n    You must modify it and make it cleaner!.\n"},
-	},
-	"size": {
-		Feedback{Value: 85, Message: "   WARNING: The functions might be long. You might want to make it smaller.\n"},
-		Feedback{Value: 120, Message: "   WARNING: The function is longer than recommended. You should consider a refactor.\n"},
-		Feedback{Value: 150, Message: "   POTENTIAL ERROR: The function is too long. You must refactor now!.\n"},
-	},
+type Message struct {
+	MinValue uint
+	Message  string
+}
+
+func NewFeedback(configAdapter *Config) *Feedback {
+	return &Feedback{
+		configAdapter: configAdapter,
+		messages:      make(map[string][]Message),
+	}
+}
+
+func (f *Feedback) GetMessages() map[string][]Message {
+	if len(f.messages) < 1 {
+		f.setMessages()
+	}
+
+	return f.messages
+}
+
+func (f *Feedback) setMessages() {
+	f.messages = map[string][]Message{
+		"parameters": {
+			Message{MinValue: f.configAdapter.Alerts.Parameters.Info, Message: "   INFO: The function takes more parameters than recommended.\n"},
+			Message{MinValue: f.configAdapter.Alerts.Parameters.Warning, Message: "   WARNING: The function is dangerous and has many responsibilities.\n    You may want to make it cleaner/readable.\n"},
+			Message{MinValue: f.configAdapter.Alerts.Parameters.Error, Message: "   POTENTIAL ERROR: The function takes too much parameters itself. You should simplify it.\n"},
+		},
+		"complexity": {
+			Message{MinValue: f.configAdapter.Alerts.Complexity.Info, Message: "   INFO: The function it's a little bit complex.\n"},
+			Message{MinValue: f.configAdapter.Alerts.Complexity.Warning, Message: "   WARNING: The function it's very complex itself. You may simplify or break it down.\n"},
+			Message{MinValue: f.configAdapter.Alerts.Complexity.Error, Message: "   POTENTIAL ERROR: The function it's too complex and unreadable, taking too much decisions.\n    You must modify it and make it cleaner!.\n"},
+		},
+		"size": {
+			Message{MinValue: f.configAdapter.Alerts.MethodSize.Info, Message: "   INFO: The functions might be long. You might want to make it smaller.\n"},
+			Message{MinValue: f.configAdapter.Alerts.MethodSize.Warning, Message: "   WARNING: The function is longer than recommended. You should consider a refactor.\n"},
+			Message{MinValue: f.configAdapter.Alerts.MethodSize.Error, Message: "   POTENTIAL ERROR: The function is too long. You must refactor now!.\n"},
+		},
+	}
 }

--- a/cmd/domain/models.go
+++ b/cmd/domain/models.go
@@ -16,7 +16,7 @@ type Point struct {
 // FunctionData - > struct made to register all the data returned by the parser and save it
 type FunctionData struct {
 	Name                                  string
-	TotalParams, Complexity, InvalidNames int
+	TotalParams, Complexity, InvalidNames uint
 	StartPosition                         Point
 	StartByte, EndByte, Size              uint
 	Feedback                              string
@@ -28,13 +28,8 @@ type Directory struct {
 	Content []os.DirEntry
 }
 
-// Config is used to save the index of the naming convention (the content might be changed to a string)
-type Config struct {
-	NamingConventionIndex int8
-}
-
 // AddInitialData Method to append the initial data into a FunctionData "object"
-func (f *FunctionData) AddInitialData(name string, totalParams int, startByte, endByte, size uint, startPos Point) {
+func (f *FunctionData) AddInitialData(name string, totalParams, startByte, endByte, size uint, startPos Point) {
 	f.Name = name
 	f.TotalParams = totalParams
 	f.StartByte = startByte
@@ -53,11 +48,11 @@ func (f *FunctionData) IsTargetInRange(startByte, endByte uint) bool {
 }
 
 // SetFunctionFeedback loops through the feedback map and sets up the right feedback
-func (f *FunctionData) SetFunctionFeedback() {
-	for key, value := range Messages {
+func (f *FunctionData) SetFunctionFeedback(messages map[string][]Message) {
+	for key, value := range messages {
 		var msg string
 		for _, item := range value {
-			if f.getValue(key) >= item.Value {
+			if f.getValue(key) >= item.MinValue {
 				msg = item.Message
 			}
 		}
@@ -66,11 +61,11 @@ func (f *FunctionData) SetFunctionFeedback() {
 }
 
 // getValue is a helper function used to get the determined integer based on a key
-func (f *FunctionData) getValue(key string) int {
-	dict := map[string]int{
+func (f *FunctionData) getValue(key string) uint {
+	dict := map[string]uint{
 		"parameters": f.TotalParams,
 		"complexity": f.Complexity,
-		"size":       int(f.Size),
+		"size":       f.Size,
 	}
 
 	return dict[key]

--- a/cmd/domain/rules.go
+++ b/cmd/domain/rules.go
@@ -38,12 +38,7 @@ var SnakeCase = "^[a-z][a-z0-9]*([_]{1}[a-z0-9]+)*$" + "|" + Constant
 // Example: pattern := AllowNonNamedVar + CamelCase
 var AllowNonNamedVar = "^[_]{1}$"
 
-var Conventions = map[int8]string{
-	1: LowerCamelCase,
-	2: UpperCamelCase,
-	3: CamelCase,
-	4: SnakeCase,
-}
+var Conventions = []string{LowerCamelCase, UpperCamelCase, CamelCase, SnakeCase}
 
 func RegexMatch(pattern, target string) bool {
 	matched, _ := regexp.MatchString(pattern, target)

--- a/cmd/lit/commands/config.go
+++ b/cmd/lit/commands/config.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"CLI_App/cmd/adapters/config"
+	"CLI_App/cmd/domain"
 	"CLI_App/cmd/lit/ui"
 
 	"github.com/spf13/cobra"
@@ -13,8 +14,9 @@ func Configuration() *cobra.Command {
 		Short: "Configure the scan variables.",
 		Run: func(cmd *cobra.Command, args []string) {
 			idx := ui.GetNamingConvention()
+			alerts := ui.GetAlertsConfig()
 			jsonAdapter := config.NewJSONAdapter()
-			newConfig := &config.ConfigDto{NamingConventionIndex: idx}
+			newConfig := &domain.Config{NamingConventionIndex: idx, Alerts: alerts}
 			jsonAdapter.SaveConfig(newConfig)
 		},
 	}

--- a/cmd/lit/commands/files.go
+++ b/cmd/lit/commands/files.go
@@ -17,9 +17,12 @@ func Files() *cobra.Command {
 			loc, _ := cmd.Flags().GetBool("loc")
 			fix, _ := cmd.Flags().GetBool("fix")
 
-			jsonAdapter := config.NewJSONAdapter()
+			configAdapter := config.NewJSONAdapter()
 			scanner := service.NewScannerService(
-				languages.NewFileAnalyzer(domain.Conventions[jsonAdapter.GetConfig().NamingConventionIndex]),
+				languages.NewFileAnalyzer(
+					domain.Conventions[configAdapter.GetConfig().NamingConventionIndex-1],
+					domain.NewFeedback(configAdapter.GetConfig()),
+				),
 			)
 
 			switch {

--- a/cmd/lit/ui/input.go
+++ b/cmd/lit/ui/input.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"CLI_App/cmd/domain"
 	"fmt"
 	"os"
 	"os/exec"
@@ -33,6 +34,51 @@ func GetNamingConvention() int8 {
 
 	// Return the pattern to use
 	return selectedConvention
+}
+
+func GetAlertsConfig() domain.Alerts {
+	clearScreen(osClear[runtime.GOOS][0], osClear[runtime.GOOS][1:]...)
+	var res []domain.FeedbackValues
+	configType := []string{
+		"Type the minimum parameters of the method to mark it as ",
+		"Type the minimum complexity of the method to mark it as ",
+		"Type the minimum length of the method to mark it as ",
+	}
+	feedbackType := []string{
+		"info\n", "warning\n", "error\n",
+	}
+
+	for _, cfg := range configType {
+		var inputs []uint
+		for _, fdb := range feedbackType {
+			inputs = append(inputs, readValue(cfg+fdb, 1, uint(300)))
+		}
+		res = append(res, domain.FeedbackValues{
+			Info:    inputs[0],
+			Warning: inputs[1],
+			Error:   inputs[2],
+		})
+	}
+
+	return domain.Alerts{
+		Parameters: res[0],
+		Complexity: res[1],
+		MethodSize: res[2],
+	}
+}
+
+func readValue[T uint | int8](message string, lowRange, highRange T) T {
+	input := lowRange - 1
+	for input < lowRange || input > highRange {
+		fmt.Printf(message)
+		fmt.Scan(&input)
+		clearScreen(osClear[runtime.GOOS][0], osClear[runtime.GOOS][1:]...)
+		if input < lowRange || input > highRange {
+			fmt.Fprintln(os.Stderr, "Invalid input...")
+		}
+	}
+
+	return input
 }
 
 // Function used to clear the screen in Windows or Linux...

--- a/config.json
+++ b/config.json
@@ -1,1 +1,1 @@
-{"activeNamingConventionIndex":3}
+{"activeNamingConventionIndex":3,"alerts":{"parameters":{"info":5,"warning":8,"error":10},"complexity":{"info":10,"warning":15,"error":20},"method-length":{"info":120,"warning":150,"error":180}}}


### PR DESCRIPTION
## **'config' command improved to let the user personalize everything**

With this update, the user can now personalize the scanner values such as the minimum parameters to make a function an info, warning or an error, etc. With this, now the user can fully control the scanner without a problem.
Being technicals, I created two new structures for the Feedback management (Feedback and Message).